### PR TITLE
Fix: Update AiGenerationService to use AiContentApi

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/ai/AiGenerationService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ai/AiGenerationService.kt
@@ -1,15 +1,15 @@
 package dev.aurakai.auraframefx.ai
 
-import dev.aurakai.auraframefx.generated.api.auraframefxai.ContentApi
-import dev.aurakai.auraframefx.generated.model.auraframefxai.GenerateImageDescriptionResponse
-import dev.aurakai.auraframefx.generated.model.auraframefxai.GenerateTextRequest
-import dev.aurakai.auraframefx.generated.model.auraframefxai.GenerateTextResponse
-import kotlinx.coroutines.CoroutineScope
+import dev.aurakai.auraframefx.api.AiContentApi
+// import dev.aurakai.auraframefx.generated.model.auraframefxai.GenerateImageDescriptionResponse // Not available in new API
+import dev.aurakai.auraframefx.api.model.GenerateTextRequest // Updated import
+import dev.aurakai.auraframefx.api.model.GenerateTextResponse // Updated import
+// import kotlinx.coroutines.CoroutineScope // Not needed if generateImageDescription is removed
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class AiGenerationService(
-    private val api: ContentApi,
+    private val api: AiContentApi, // Updated type
 ) {
     suspend fun generateText(
         prompt: String,
@@ -17,7 +17,7 @@ class AiGenerationService(
         temperature: Float = 0.7f,
     ): Result<GenerateTextResponse> = withContext(Dispatchers.IO) {
         try {
-            val request = GenerateTextRequest(
+            val request = GenerateTextRequest( // This will now use the new model
                 prompt = prompt,
                 maxTokens = maxTokens,
                 temperature = temperature
@@ -29,38 +29,41 @@ class AiGenerationService(
         }
     }
 
-    suspend fun generateImageDescription(
-        imageUrl: String,
-        context: String? = null,
-        prompt: String? = null,
-        maxTokens: Int? = null,
-        model: String? = null,
-        imageData: ByteArray? = null,
-    ): Result<GenerateImageDescriptionResponse> = withContext(Dispatchers.IO) {
-        try {
-            val request = GenerateImageDescriptionRequest(
-                imageUrl = imageUrl,
-                context = context,
-                imageData = imageData,
-                prompt = prompt,
-                maxTokens = maxTokens,
-                model = model
-            )
-            val response = api.generateImageDescription(request)
-            Result.success(response)
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
+    // suspend fun generateImageDescription(
+    //     imageUrl: String,
+    //     context: String? = null,
+    //     prompt: String? = null,
+    //     maxTokens: Int? = null,
+    //     model: String? = null,
+    //     imageData: ByteArray? = null,
+    // ): Result<GenerateImageDescriptionResponse> = withContext(Dispatchers.IO) {
+    //     try {
+    //         // The request model dev.aurakai.auraframefx.generated.model.auraframefxai.GenerateImageDescriptionRequest
+    //         // is also from the old generated source and would need to be handled if this method were kept.
+    //         // val request = GenerateImageDescriptionRequest(
+    //         //     imageUrl = imageUrl,
+    //         //     context = context,
+    //         //     imageData = imageData,
+    //         //     prompt = prompt,
+    //         //     maxTokens = maxTokens,
+    //         //     model = model
+    //         // )
+    //         // val response = api.generateImageDescription(request) // This method doesn't exist on AiContentApi
+    //         // Result.success(response)
+    //         Result.failure(UnsupportedOperationException("generateImageDescription is not supported in the current API"))
+    //     } catch (e: Exception) {
+    //         Result.failure(e)
+    //     }
+    // }
 
-    private fun CoroutineScope.GenerateImageDescriptionRequest(
-        imageUrl: String,
-        context: String?,
-        imageData: ByteArray?,
-        prompt: String?,
-        maxTokens: Int?,
-        model: String?,
-    ) {
-        TODO("Not yet implemented")
-    }
+    // private fun CoroutineScope.GenerateImageDescriptionRequest(
+    //     imageUrl: String,
+    //     context: String?,
+    //     imageData: ByteArray?,
+    //     prompt: String?,
+    //     maxTokens: Int?,
+    //     model: String?,
+    // ) {
+    //     TODO("Not yet implemented")
+    // }
 }


### PR DESCRIPTION
- Corrected AiGenerationService.kt to import and use AiContentApi from the `dev.aurakai.auraframefx.api` package, resolving the last known incorrect reference to the old ContentApi.
- Updated model imports in AiGenerationService.kt to use those from `dev.aurakai.auraframefx.api.model`.
- Commented out `generateImageDescription` in AiGenerationService.kt as it's not available in AiContentApi.

This change, along with previous updates to Hilt modules and the OpenAPI spec, is intended to resolve the KSP errors related to ContentApi resolution. Full build and test verification should be performed in an environment with a configured Android SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of text generation requests with an updated API.
* **Removed Features**
  * Image description generation is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->