### PR TITLE
Feat: Add generateOpenApiContract Gradle task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,7 +148,18 @@ val generatePythonClient by tasks.registering(org.openapitools.generator.gradle.
     configOptions.set(mapOf(
         "packageName" to "auraframefx_api_client"
     ))
-} // Add missing closing brace
+}
+
+tasks.register("generateOpenApiContract") {
+    group = "OpenAPI tools"
+    description = "Generates all OpenAPI client artifacts (Kotlin, TypeScript, Java, Python)."
+    dependsOn(
+        "openApiGenerate",
+        "generateTypeScriptClient",
+        "generateJavaClient",
+        generatePythonClient // Use the val here
+    )
+}
 
 // Ensure codegen runs before build
 // Ensure OpenAPI generation runs before KSP and compilation


### PR DESCRIPTION
Adds a new aggregate Gradle task named `generateOpenApiContract` to the `app/build.gradle.kts` file.

This task depends on and triggers the following existing tasks:
- openApiGenerate (Kotlin client)
- generateTypeScriptClient (TypeScript client)
- generateJavaClient (Java client)
- generatePythonClient (Python client)

This allows users to generate all OpenAPI clients by running the single command `./gradlew generateOpenApiContract`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new build task to generate all OpenAPI client artifacts for multiple languages with a single command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->