### PR TITLE
Refactor: Standardize sourceSet configuration in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,20 +59,29 @@ android {
 
     sourceSets {
         getByName("main") {
-            aidl.srcDirs("src/main/aidl")
-            java.setSrcDirs(listOf(
-                "src/main/java",
-                "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/kotlin",
-                "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/java",
-                "${layout.buildDirectory.get().asFile}/generated/ksp/debug/java",
-                "${layout.buildDirectory.get().asFile}/generated/ksp/release/java"
-            ))
-            kotlin.setSrcDirs(listOf(
-                "src/main/kotlin",
-                "${layout.buildDirectory.get().asFile}/generated/ksp/debug/kotlin",
-                "${layout.buildDirectory.get().asFile}/generated/ksp/release/kotlin"
-            ))
-            aidl.setSrcDirs(listOf("src/main/aidl"))
+            aidl {
+                srcDirs("src/main/aidl")
+            }
+            java {
+                // Using setSrcDirs should be fine, the error is puzzling.
+                // This explicitly sets these as the source directories, replacing defaults.
+                setSrcDirs(listOf(
+                    "src/main/java",
+                    "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/kotlin",
+                    "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/java",
+                    "${layout.buildDirectory.get().asFile}/generated/ksp/debug/java",
+                    "${layout.buildDirectory.get().asFile}/generated/ksp/release/java"
+                ))
+            }
+            kotlin {
+                // Using setSrcDirs should be fine.
+                setSrcDirs(listOf(
+                    "src/main/kotlin",
+                    "${layout.buildDirectory.get().asFile}/generated/ksp/debug/kotlin",
+                    "${layout.buildDirectory.get().asFile}/generated/ksp/release/kotlin"
+                ))
+            }
+            // Removed redundant aidl.setSrcDirs from original line 75
         }
     }
     ndkVersion = "26.2.11394342"


### PR DESCRIPTION
Refactored the `sourceSets.main` block to use the closure configuration style for `aidl`, `java`, and `kotlin` source sets. Removed a redundant `aidl.setSrcDirs` line.

This aims to address potential unresolved reference errors for `aidl` and `java.setSrcDirs` by using a more conventional DSL structure, particularly if AGP version changes affected how these are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the configuration of source directories for AIDL, Java, and Kotlin files, making the setup more explicit and maintainable. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->