### PR TITLE
Revert: Revert sourceSets structure in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,29 +59,20 @@ android {
 
     sourceSets {
         getByName("main") {
-            aidl {
-                srcDirs("src/main/aidl")
-            }
-            java {
-                // Using setSrcDirs should be fine, the error is puzzling.
-                // This explicitly sets these as the source directories, replacing defaults.
-                setSrcDirs(listOf(
-                    "src/main/java",
-                    "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/kotlin",
-                    "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/java",
-                    "${layout.buildDirectory.get().asFile}/generated/ksp/debug/java",
-                    "${layout.buildDirectory.get().asFile}/generated/ksp/release/java"
-                ))
-            }
-            kotlin {
-                // Using setSrcDirs should be fine.
-                setSrcDirs(listOf(
-                    "src/main/kotlin",
-                    "${layout.buildDirectory.get().asFile}/generated/ksp/debug/kotlin",
-                    "${layout.buildDirectory.get().asFile}/generated/ksp/release/kotlin"
-                ))
-            }
-            // Removed redundant aidl.setSrcDirs from original line 75
+            aidl.srcDirs("src/main/aidl") // Reverted to original direct access
+            java.setSrcDirs(listOf(       // Reverted to original direct access
+                "src/main/java",
+                "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/kotlin",
+                "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/java",
+                "${layout.buildDirectory.get().asFile}/generated/ksp/debug/java",
+                "${layout.buildDirectory.get().asFile}/generated/ksp/release/java"
+            ))
+            kotlin.setSrcDirs(listOf(     // Reverted to original direct access
+                "src/main/kotlin",
+                "${layout.buildDirectory.get().asFile}/generated/ksp/debug/kotlin",
+                "${layout.buildDirectory.get().asFile}/generated/ksp/release/kotlin"
+            ))
+            // The redundant aidl line that was here is kept removed.
         }
     }
     ndkVersion = "26.2.11394342"


### PR DESCRIPTION
Reverted the `sourceSets.main` block to its previous structure (direct `aidl.srcDirs` and `java.setSrcDirs` calls) to diagnose the cause of the widespread "Unexpected symbol" errors.

This is to check if the refactoring to a closure style for source sets was the trigger for the new syntax errors, or if the underlying "Unresolved reference: aidl / java.setSrcDirs" errors persist, indicating a deeper AGP/DSL issue.