### PR TITLE
Fix: Specify Xposed API JAR directly in Gradle dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -283,5 +283,5 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Xposed API - local JARs from app/Libs
-    implementation(fileTree(mapOf("dir" to "app/Libs", "include" to listOf("*.jar"))))
+    implementation(files("app/Libs/api-82.jar"))
 }


### PR DESCRIPTION
Changed the Xposed API dependency declaration in app/build.gradle.kts from fileTree to a direct files() reference for api-82.jar. This is an attempt to resolve persistent unresolved reference errors for Xposed classes during compilation.