### PR TITLE
Fix: Resolve KSP and Compose tooling errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ android {
             )
             kotlin.srcDirs(
                 "src/main/kotlin",
+                "${layout.buildDirectory.get().asFile}/generated/kotlin/src/main/kotlin", // Added path for OpenAPI generated Kotlin
                 "${layout.buildDirectory.get().asFile}/generated/ksp/debug/kotlin",
                 "${layout.buildDirectory.get().asFile}/generated/ksp/release/kotlin"
             )
@@ -281,6 +282,7 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.animation.tooling) // Added for Compose animation tooling
 
     // Xposed API - local JARs from app/Libs
     implementation(files("app/Libs/api-82.jar"))


### PR DESCRIPTION
- Added OpenAPI generated Kotlin path to kotlin.srcDirs in app/build.gradle.kts to allow KSP to find generated API client classes like AiContentApi.
- Added debugImplementation for androidx.compose.animation:animation-tooling to resolve ComposeAnimatedProperty unresolved reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for Compose animation tooling during debug builds.

* **Chores**
  * Updated build configuration to include generated Kotlin code from the OpenAPI generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->