### PR TITLE
Build: Revert Xposed dependency to fileTree

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -285,5 +285,5 @@ dependencies {
     debugImplementation(libs.androidxAnimationTooling) // Corrected alias for Compose animation tooling
 
     // Xposed API - local JARs from app/Libs
-    implementation(files("app/Libs/api-82.jar"))
+    implementation(fileTree(mapOf("dir" to "app/Libs", "include" to listOf("*.jar"))))
 }


### PR DESCRIPTION
Reverted the Xposed API dependency in app/build.gradle.kts back to using fileTree. This is to restore the standard way of including local JARs while investigating persistent KSP errors for ContentApi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to automatically include all JAR files in the specified directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->