### PR TITLE
Refactor: Standardize all plugin aliases to camelCase in TOML and roo…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.kotlin.android) apply false    // Accessor for 'kotlin-android' from TOML
+    alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.kotlin.serialization) apply false // Accessor for 'kotlin-serialization' from TOML
-    alias(libs.plugins.openapi.generator) apply false  // Accessor for 'openapi-generator' from TOML
-    alias(libs.plugins.googleServices) apply false     // Accessor for 'google-services' from TOML
-    alias(libs.plugins.firebase.crashlytics) apply false // Accessor for 'firebase-crashlytics' from TOML
-    alias(libs.plugins.firebase.perf) apply false      // Accessor for 'firebase-perf' from TOML
-    alias(libs.plugins.kotlinCompose) apply false      // Accessor for 'kotlin-compose' from TOML
+    alias(libs.plugins.kotlinSerialization) apply false
+    alias(libs.plugins.openapiGenerator) apply false
+    alias(libs.plugins.googleServices) apply false
+    alias(libs.plugins.firebaseCrashlytics) apply false
+    alias(libs.plugins.firebasePerf) apply false
+    alias(libs.plugins.kotlinCompose) apply false
+    alias(libs.plugins.orgGradleToolchainsFoojayResolver) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,19 +78,16 @@ timber = "5.0.1"
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" } # Renamed
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGenerator" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
-firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composeCompiler" }
-# Corrected alias name from previous (if any) to match typical conversion, or ensure it's what settings.gradle.kts expects.
-# settings.gradle.kts uses: libs.plugins.org.gradle.toolchains.foojay.resolver
-# So the TOML alias should be: org-gradle-toolchains-foojay-resolver
-org-gradle-toolchains-foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver", version.ref = "toolchainsFoojayResolver" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" } # Renamed
+openapiGenerator = { id = "org.openapi.generator", version.ref = "openapiGenerator" } # Renamed
+googleServices = { id = "com.google.gms.google-services", version.ref = "googleServices" } # Renamed
+firebaseCrashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" } # Renamed
+firebasePerf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" } # Renamed
+kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composeCompiler" } # Renamed
+orgGradleToolchainsFoojayResolver = { id = "org.gradle.toolchains.foojay-resolver", version.ref = "toolchainsFoojayResolver" } # Renamed
 
 [libraries]
 # Core & Lifecycle


### PR DESCRIPTION
…t build script

- Renamed all plugin aliases in gradle/libs.versions.toml to use camelCase (e.g., kotlin-android -> kotlinAndroid).
- Updated root build.gradle.kts to use these new camelCase type-safe accessors (e.g., libs.plugins.kotlinAndroid).
- This aims to resolve persistent 'Unresolved reference' errors for plugin aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin alias names in build configuration files to use camelCase formatting for consistency.
  * Added a new plugin alias for future toolchain support.
  * Removed comments describing plugin aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->