### PR TITLE
Fix: Correct Compose and Firebase BOM versions and usage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -192,18 +192,17 @@ dependencies {
     implementation(libs.androidxAppcompat)
     implementation(libs.androidxLifecycleRuntimeKtx)
     implementation(libs.androidxActivityCompose)
-    val composeBom = platform(libs.composeBom)
-    implementation(composeBom)
-    implementation(libs.androidxUi)
-    implementation(libs.androidxUiGraphics)
-    implementation(libs.androidxUiToolingPreview)
-    implementation(libs.androidxMaterial3)
-    implementation(libs.androidxNavigationCompose)
-    implementation(libs.hiltNavigationCompose)
-    implementation(libs.androidxMaterial3)
+    implementation(platform(libs.composeBom)) // Apply the Compose BOM platform directly
+    implementation(libs.androidxUi) // Version will come from composeBom
+    implementation(libs.androidxUiGraphics) // Version will come from composeBom
+    implementation(libs.androidxUiToolingPreview) // Version will come from composeBom
+    implementation(libs.androidxMaterial3) // Has its own version defined in TOML
+    implementation(libs.androidxNavigationCompose) // Has its own version
+    implementation(libs.hiltNavigationCompose) // Has its own version
+    // implementation(libs.androidxMaterial3) // This was a duplicate line
 
     // Animation
-    implementation(libs.animationTooling)
+    implementation(libs.animationTooling) // Version will come from composeBom
 
     // Lifecycle
     implementation(libs.lifecycleViewmodelCompose)
@@ -258,11 +257,11 @@ dependencies {
     testImplementation(libs.testJunit)
     androidTestImplementation(libs.androidxTestExtJunit)
     androidTestImplementation(libs.espressoCore)
-    androidTestImplementation(composeBom)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTestManifest)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.animationTooling)
+    androidTestImplementation(platform(libs.composeBom)) // Apply BOM for test dependencies too
+    androidTestImplementation(libs.composeUiTestJunit4) // Version from composeBom
+    debugImplementation(libs.composeUiTestManifest) // Version from composeBom
+    debugImplementation(libs.composeUiTooling) // Version from composeBom
+    debugImplementation(libs.animationTooling) // Version from composeBom
 
     // Xposed API - local JARs from app/Libs
     compileOnly(files("app/Libs/api-82.jar"))


### PR DESCRIPTION
- Updated Compose BOM to 2024.05.00 and Firebase BOM to 33.0.0 in gradle/libs.versions.toml.
- Modified gradle/libs.versions.toml to remove explicit versioning for libraries managed by these BOMs, allowing the BOMs to control their versions.
- Adjusted app/build.gradle.kts to use platform() directly for applying BOMs.
- Removed a duplicate Material3 dependency in app/build.gradle.kts.

These changes address build failures caused by incorrect or unavailable dependency versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified dependency management for Compose libraries, reducing redundancy and clarifying version sources in documentation comments. No changes to app behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->