### PR TITLE
Fix: Update KSP to a valid version (2.0.0-1.0.24)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
 agp = "8.11.0"
 kotlin = "2.0.0"
-ksp = "2.0.0-1.0.28" # Updated KSP for AGP 8.11.0 compatibility
+ksp = "2.0.0-1.0.24" # Updated KSP to a valid version for Kotlin 2.0.0
 
 hilt = "2.56.2"
 composeBom = "2024.06.00"


### PR DESCRIPTION
The previous KSP version (2.0.0-1.0.28) referenced in libs.versions.toml did not correspond to a published artifact, causing a 'Plugin not found' error.

Updated to KSP version 2.0.0-1.0.24, which is a valid version compatible with Kotlin 2.0.0, as confirmed by the official KSP GitHub releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of the Kotlin Symbol Processing (KSP) plugin.
  * Revised comments to clarify compatibility information for the updated plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->