### PR TITLE
Fix: Explicitly enable KSP2 via ksp.useKSP2=true

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
 agp = "8.11.0"
 kotlin = "2.0.0"
-ksp = "2.0.0-1.0.24" # Updated KSP to a valid version for Kotlin 2.0.0
+ksp = "2.0.20-1.0.25" # Updated KSP for Kotlin 2.0.x, hoping for better Gradle 8.13 API compatibility
 
 hilt = "2.56.2"
 composeBom = "2024.06.00"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Ensuring KSP2 is active, as it's the default for KSP 2.0.20-1.0.25. This is to ensure the build runs with the intended KSP engine configuration\while troubleshooting the KspAATask error with AGP 8.11.0 / Gradle 8.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Kotlin Symbol Processing (KSP) plugin to a newer version.
  * Updated the Gradle build system to version 8.13 for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->