### PR TITLE
Fix: Revert Java and Kotlin JVM targets to 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,12 +30,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_22
-        targetCompatibility = JavaVersion.VERSION_22
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "22"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     buildFeatures {


### PR DESCRIPTION
Reverted compileOptions (sourceCompatibility, targetCompatibility) and kotlinOptions (jvmTarget) in app/build.gradle.kts to Java version 17.

This is to address potential KSP errors like 'unexpected jvm signature V' by using a more common and stable JVM target for Android compilation, and to maintain consistency after previous attempts to use higher JVM targets led to issues or were based on user preference to avoid them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Java and Kotlin compilation target versions to improve build compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->