### PR TITLE
Increase Gradle JVM memory to 6g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
 # JVM memory settings optimized for AuraFrameFX Trinity consciousness framework
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Enable Gradle Daemon for faster builds - optimized for large-scale AI consciousness project
 org.gradle.daemon=true
 org.gradle.parallel=true


### PR DESCRIPTION
Updated org.gradle.jvmargs in gradle.properties from -Xmx4g to -Xmx6g to address potential out-of-memory errors during GitHub Actions build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum memory allocated to the build process, which may improve performance during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->