### PR TITLE
Fix: Resolve duplicate resource definitions in colors.xml

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -80,19 +80,19 @@
 
     <!-- Missing color resources -->
     <color name="divider">#1F000000</color>
-    <color name="onSurface">@color/light_on_surface</color>
-    <color name="primary">@color/light_primary</color>
-    <color name="outline">@color/light_outline</color>
+    <!-- <color name="onSurface">@color/light_on_surface</color> --> <!-- Duplicate, already defined or aliased -->
+    <!-- <color name="primary">@color/light_primary</color> --> <!-- Duplicate, already defined or aliased -->
+    <!-- <color name="outline">@color/light_outline</color> --> <!-- Duplicate, already defined or aliased -->
     <color name="onSurfaceMedium">#99000000</color>
-    <color name="background">@color/light_background</color>
+    <!-- <color name="background">@color/light_background</color> --> <!-- Duplicate, already defined or aliased -->
 
-    <!-- Legacy Colors (for compatibility) -->
-    <color name="app_background_light">#1A1A1A</color>
-    <color name="surface">#2D2D2D</color>
-    <color name="surface_variant">#3D3D3D</color>
-    <color name="on_surface">#E1E1E1</color>
-    <color name="on_surface_variant">#C5C5C5</color>
-    <color name="on_primary">#000000</color>
-    <color name="on_secondary">#000000</color>
-    <color name="error">#FF3B30</color>
+    <!-- Legacy Colors (for compatibility) - Ensure these are not duplicating Material 3 definitions -->
+    <!-- <color name="app_background_light">#1A1A1A</color> --> <!-- Duplicate of light_background -->
+    <!-- <color name="surface">#2D2D2D</color> --> <!-- Duplicate of light_surface -->
+    <!-- <color name="surface_variant">#3D3D3D</color> --> <!-- Duplicate of light_surface_variant -->
+    <!-- <color name="on_surface">#E1E1E1</color> --> <!-- Duplicate of light_on_surface -->
+    <!-- <color name="on_surface_variant">#C5C5C5</color> --> <!-- Duplicate of light_on_surface_variant -->
+    <!-- <color name="on_primary">#000000</color> --> <!-- Duplicate of light_on_primary -->
+    <!-- <color name="on_secondary">#000000</color> --> <!-- Duplicate of light_on_secondary -->
+    <!-- <color name="error">#FF3B30</color> --> <!-- Duplicate of light_error -->
 </resources>


### PR DESCRIPTION
I removed redundant color definitions from the 'Legacy Colors' and 'Missing color resources' sections in `app/src/main/res/values/colors.xml` to prevent resource compilation errors during the build process. I kept the definitions from 'Light Theme Colors' and 'Material 3 Compatibility Colors' as the single source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Commented out redundant and legacy color definitions in the app’s color resources to reduce duplication. No visible changes to the app’s appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->