### PR TITLE
Fix: Correct NDK installation in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          ndk-version: 26.2.11394342
+          packages: "ndk;26.2.11394342 platform-tools tools"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
- I updated the 'Set up Android SDK' step in `main.yml` to use the `packages` input for `android-actions/setup-android@v3`.
- This ensures the NDK (version 26.2.11394342), platform-tools, and tools are correctly installed.
- I removed the unsupported `ndk-version` parameter, which was causing a warning and preventing proper NDK setup, leading to subsequent build failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to install multiple Android SDK components, including a specific NDK version, platform-tools, and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->