### PR TITLE
Fix: Align AGP, Kotlin, KSP, and Compose Compiler versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication)version("8.1.1") apply false
+    alias(libs.plugins.androidApplication)version("8.5.0") apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
-agp = "8.13.0"  # Updated to latest stable version
+agp = "8.5.0"  # Updated to be compatible with Kotlin 2.2.0
 generativeai = "0.9.0"
 kotlin = "2.2.0" # Reverted as per user request
 ksp = "2.2.0-2.0.2" # Reverted as per user request (aligned with Kotlin 2.2.0)


### PR DESCRIPTION
- I updated the Android Gradle Plugin (AGP) to 8.5.0 in your root `build.gradle.kts` and `gradle/libs.versions.toml` for compatibility with Kotlin 2.2.0.
- I verified that your Kotlin version is 2.2.0.
- I verified that your KSP version is 2.2.0-2.0.2 (for Kotlin 2.2.0).
- I verified that your Compose Compiler version is 2.2.0 (for Kotlin 2.2.0).

These changes address KSP build failures caused by version incompatibilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android Application plugin and Android Gradle Plugin versions to 8.5.0 for improved compatibility with Kotlin 2.2.0.
  * Ensured Kotlin Symbol Processing (KSP) plugin remains aligned with Kotlin 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->