### PR TITLE
I've updated Gradle to 8.11 and AGP to 8.9.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication)version("8.5.0") apply false
+    alias(libs.plugins.androidApplication)version("8.9") apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
-agp = "8.5.0"  # Updated to be compatible with Kotlin 2.2.0
+agp = "8.9"  # Updated as per user request
 generativeai = "0.9.0"
 kotlin = "2.2.0" # Reverted as per user request
 ksp = "2.2.0-2.0.2" # Reverted as per user request (aligned with Kotlin 2.2.0)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- I set the Gradle wrapper version to 8.11.
- I set the Android Gradle Plugin (AGP) version to 8.9.
- I kept Kotlin at 2.2.0, KSP at 2.2.0-2.0.2, and Compose Compiler at 2.2.0 in an attempt to use these with the updated Gradle/AGP versions.

I'll assess further compatibility when I build the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android Gradle Plugin to version 8.9.
  * Reverted Kotlin and Kotlin Symbol Processing plugin versions to 2.2.0 and 2.2.0-2.0.2.
  * Downgraded Gradle wrapper version to 8.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->