### PR TITLE
Fix: Use JDK 21 in CI for Gradle 8.11 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 24  # Changed name
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '24' # Changed to JDK 24
+          java-version: '21'
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
I've updated the GitHub Actions workflow to set up JDK 21. Gradle 8.11 requires a more recent JDK ( JDK 11+, typically JDK 17 or 21 for modern builds) to run the daemon. This change ensures Gradle can run correctly, while your project code continues to target Java 17 for compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use JDK version 21 instead of JDK version 24 in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->