### PR TITLE
Fix: Resolve Kotlin Compose plugin resolution failure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ksp = "2.2.0-2.0.2" # Latest stable KSP for Kotlin 2.2.0
 hilt = "2.56.2" # Current version in project, requires compatible KSP
 composeBom = "2025.06.01" # As per Dependabot PR #634
 composeCompiler = "2.2.0" # Aligned with Kotlin 2.2.0
+kotlinComposePlugin = "1.5.12" # Stable Compose Gradle Plugin version
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---
@@ -147,6 +148,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGeneratorPlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
-kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlin" } # Corrected plugin ID
+kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlinComposePlugin" } # Uses specific plugin version
 gradle-toolchains-foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "toolchainsFoojayResolver" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
     // Commenting out problematic resolutionStrategy to let libs.versions.toml manage Kotlin plugin versions
     // resolutionStrategy {


### PR DESCRIPTION
- Added the JetBrains Compose maven repository (`https://maven.pkg.jetbrains.space/public/p/compose/dev`) to `pluginManagement` in `settings.gradle.kts`.
- Set a specific, stable version for the Kotlin Compose Gradle plugin (`1.5.12`) in `libs.versions.toml` instead of inheriting the Kotlin version.

This should allow Gradle to find and resolve the `org.jetbrains.kotlin.compose` plugin.