### PR TITLE
Fix: Align Kotlin Compose Gradle plugin version with Kotlin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ ksp = "2.2.0-2.0.2" # Latest stable KSP for Kotlin 2.2.0
 hilt = "2.56.2" # Current version in project, requires compatible KSP
 composeBom = "2025.06.01" # As per Dependabot PR #634
 composeCompiler = "2.2.0" # Aligned with Kotlin 2.2.0
-kotlinComposePlugin = "1.5.12" # Stable Compose Gradle Plugin version
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---
@@ -148,6 +147,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGeneratorPlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
-kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlinComposePlugin" } # Uses specific plugin version
+kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlin" } # Align with Kotlin version
 gradle-toolchains-foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "toolchainsFoojayResolver" }
 


### PR DESCRIPTION
- Removed the separate `kotlinComposePlugin` version from `libs.versions.toml`.
- Updated the `kotlin-compose` plugin alias to use `version.ref = "kotlin"`.

This ensures the Compose Gradle plugin version correctly aligns with the main Kotlin plugin version (2.2.0), which is the standard practice. The Compose Compiler Extension version remains explicitly set via `composeCompiler` (2.2.0) in `composeOptions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version references to align the Kotlin Compose plugin version with the main Kotlin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->