### PR TITLE
I reverted the versions in `libs.versions.toml` to a known stable set:

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build debug APK
-        run: ./gradlew assembleDebug
+        run: ./gradlew clean assembleDebug
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication) version "8.11.1" apply false
+    alias(libs.plugins.androidApplication) version "8.2.2" apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
-agp = "8.11.1"  # Aligning with Dependabot PR #632
+agp = "8.2.2"
 generativeai = "0.9.0"
-kotlin = "2.2.0" # Latest stable Kotlin, aligning with new BOM
-ksp = "2.2.0-2.0.2" # Latest stable KSP for Kotlin 2.2.0
-hilt = "2.56.2" # Current version in project, requires compatible KSP
-composeBom = "2025.06.01" # As per Dependabot PR #634
-composeCompiler = "2.2.0" # Aligned with Kotlin 2.2.0
+kotlin = "1.9.22"
+ksp = "1.9.22-1.0.17"
+hilt = "2.51.1"
+composeBom = "2024.05.00"
+composeCompiler = "1.5.8"
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---


### PR DESCRIPTION
- AGP: 8.2.2
- Kotlin: 1.9.22
- KSP: 1.9.22-1.0.17
- Compose Compiler: 1.5.8
- Hilt: 2.51.1

I also updated the AGP version in the root `build.gradle.kts` to 8.2.2, ensured the kotlin-compose plugin in the catalog uses the Kotlin version, verified `settings.gradle.kts` has the required plugin repositories, and added `clean` to the `./gradlew assembleDebug` command in the CI workflow.

This should establish a stable build environment by using a known compatible set of versions and ensuring a clean build in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to clean the build directory before assembling the debug APK.
  * Downgraded versions of several core dependencies and toolchain components, including Android Gradle Plugin, Kotlin, KSP, Hilt, and Jetpack Compose.
* **Refactor**
  * Adjusted project configuration to align with downgraded dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->