### PR TITLE
Fix: Correct Kotlin Compose plugin versioning to stable 1.6.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ksp = "1.9.22-1.0.17"
 hilt = "2.51.1"
 composeBom = "2024.05.00"
 composeCompiler = "1.5.8"
+kotlinComposePlugin = "1.6.10"
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---
@@ -147,6 +148,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGeneratorPlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
-kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlin" } # Align with Kotlin version
+kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlinComposePlugin" }
 gradle-toolchains-foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "toolchainsFoojayResolver" }
 


### PR DESCRIPTION
- I updated `gradle/libs.versions.toml` to set the `org.jetbrains.kotlin.compose` Gradle plugin to version `1.6.10`, which is a known stable version, instead of tying it to the Kotlin version.
- The rest of the toolchain remains on the stable configuration (AGP 8.2.2, Kotlin 1.9.22, etc.).

This directly addresses the plugin resolution failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version reference for the Kotlin Compose plugin to a dedicated version key. No changes to plugin IDs or other versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->