### PR TITLE
Fix: Simplify Compose plugin application

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.google.services)
-    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.openapi.generator)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ ksp = "1.9.22-1.0.17"
 hilt = "2.51.1"
 composeBom = "2024.05.00"
 composeCompiler = "1.5.8"
-kotlinComposePlugin = "1.6.10"
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---
@@ -148,6 +147,5 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGeneratorPlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
-kotlin-compose = { id = "org.jetbrains.kotlin.compose", version.ref = "kotlinComposePlugin" }
 gradle-toolchains-foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "toolchainsFoojayResolver" }
 


### PR DESCRIPTION
- Removed the explicit application of the `kotlin-compose` plugin from `app/build.gradle.kts`.
- Removed the corresponding `kotlin-compose` alias and version from `gradle/libs.versions.toml`.

This tests the hypothesis that the `kotlin.android` plugin, combined with `buildFeatures { compose = true }`, is sufficient to enable Compose, which could resolve the persistent plugin resolution errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed configuration entries related to the Kotlin Compose plugin from the project setup. No impact on app features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->