### PR TITLE
Feat: Update to modern toolchain with direct plugin application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication) version "8.2.2" apply false
-    alias(libs.plugins.kotlinAndroid) apply false
-    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.androidApplication) version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.compose") version "2.2.0" apply false
+    id("com.google.devtools.ksp") version "2.2.0-1.0.21" apply false
     alias(libs.plugins.hilt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
-agp = "8.2.2"
+agp = "8.11.1"
 generativeai = "0.9.0"
-kotlin = "1.9.22"
-ksp = "1.9.22-1.0.17"
-hilt = "2.51.1"
-composeBom = "2024.05.00"
-composeCompiler = "1.5.8"
+kotlin = "2.2.0"
+ksp = "2.2.0-1.0.21"
+hilt = "2.56.2"
+composeBom = "2025.06.01"
+composeCompiler = "2.2.0"
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---


### PR DESCRIPTION
- Updated libs.versions.toml to use Kotlin 2.2.0, AGP 8.11.1, Compose BOM 2025.06.01, and related versions.
- Modified root build.gradle.kts to apply Kotlin, Compose, and KSP plugins directly with versions instead of using aliases.

This aligns with modern Gradle practices and aims to resolve persistent plugin resolution issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android Gradle Plugin, Kotlin, KSP, Hilt, and Compose dependencies to newer versions.
  * Switched to explicit plugin IDs and versions for Kotlin Android, Kotlin Compose, and KSP plugins in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->