### PR TITLE
Fix: Correctly configure Jetpack Compose for Android

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,7 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
     alias(libs.plugins.androidApplication) version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
-    id("org.jetbrains.kotlin.compose") version "2.2.0" apply false
-    id("com.google.devtools.ksp") version "2.2.0-1.0.21" apply false
+    alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
 }


### PR DESCRIPTION
- Removed the non-existent `org.jetbrains.kotlin.compose` Gradle plugin from the root `build.gradle.kts`.
- Removed the corresponding unnecessary alias from `libs.versions.toml`.

This corrects the build configuration to use the standard method of enabling Compose for Android, which is handled by the `org.jetbrains.kotlin.android` plugin via the `buildFeatures` and `composeOptions` blocks. This should resolve the persistent plugin resolution failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin management to use centralized version aliases, improving consistency and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->