### PR TITLE
Fix: Correct KSP version and clean up plugin application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication) version "8.11.1" apply false
+    alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 agp = "8.11.1"
 generativeai = "0.9.0"
 kotlin = "2.2.0"
-ksp = "2.2.0-1.0.21"
+ksp = "2.2.0-2.0.2"
 hilt = "2.56.2"
 composeBom = "2025.06.01"
 composeCompiler = "2.2.0"


### PR DESCRIPTION
- I've updated the KSP version to 2.2.0-2.0.2 in `libs.versions.toml` to use the latest stable version for Kotlin 2.2.0.
- I also refactored the root `build.gradle.kts` to consistently use aliases from the version catalog for all plugins.

This should resolve the KSP plugin resolution failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of the Kotlin Symbol Processing (KSP) plugin.
  * Adjusted plugin configuration to remove explicit version specification for the Android application plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->