### PR TITLE
Fix: Revert to stable toolchain and correct plugin configurations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // build.gradle.kts (PROJECT LEVEL)
 plugins {
-    alias(libs.plugins.androidApplication) apply false
+    alias(libs.plugins.androidApplication) version "8.2.2" apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 # --- CORE TOOLCHAIN: THE LATEST PUBLIC RELEASES ---
-agp = "8.11.1"
+agp = "8.2.2"
 generativeai = "0.9.0"
-kotlin = "2.2.0"
-ksp = "2.2.0-2.0.2"
-hilt = "2.56.2"
-composeBom = "2025.06.01"
-composeCompiler = "2.2.0"
+kotlin = "1.9.22"
+ksp = "1.9.22-1.0.17"
+hilt = "2.51.1"
+composeBom = "2024.05.00"
+composeCompiler = "1.5.8"
 googleServices = "4.4.2" # Stable Google Services plugin (keeping this update)
 
 # --- APP Dependencies ---


### PR DESCRIPTION
- Reverted versions in libs.versions.toml to a known stable set (AGP 8.2.2, Kotlin 1.9.22, KSP 1.9.22-1.0.17, etc.).
- Corrected the root `build.gradle.kts` to use aliases and the correct AGP version.
- Verified `app/build.gradle.kts` and `settings.gradle.kts` are correctly configured.
- Ensured the CI workflow uses the `clean` task.

This is a comprehensive revert to a known stable configuration to resolve persistent build errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several core toolchain dependencies to earlier stable versions, including Android Gradle Plugin, Kotlin, Kotlin Symbol Processing, Hilt, and Compose libraries. No changes to app features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->